### PR TITLE
Don't load config with init function

### DIFF
--- a/cachet/config.go
+++ b/cachet/config.go
@@ -13,11 +13,10 @@ import (
 	"os"
 )
 
-// Static config
-var Config CachetConfig
 
 // Central logger
 var Logger *log.Logger
+var Config CachetConfig
 
 // CachetConfig is the monitoring tool configuration
 type CachetConfig struct {
@@ -29,7 +28,7 @@ type CachetConfig struct {
 	InsecureAPI bool       `json:"insecure_api"`
 }
 
-func init() {
+func LoadCachetConfigClassic() {
 	var configPath string
 	var systemName string
 	var logPath string
@@ -108,6 +107,25 @@ func init() {
 		}
 	}
 
+	flags := log.Llongfile | log.Ldate | log.Ltime
+	if len(os.Getenv("DEVELOPMENT")) > 0 {
+		flags = 0
+	}
+
+	Logger = log.New(logWriter, "", flags)
+}
+
+func LoadEmptyConfig() {
+	var logWriter io.Writer
+	logWriter = os.Stdout
+	Config = CachetConfig{}
+	if len(os.Getenv("CACHET_API")) > 0 {
+		Config.APIUrl = os.Getenv("CACHET_API")
+	}
+	if len(os.Getenv("CACHET_TOKEN")) > 0 {
+		Config.APIToken = os.Getenv("CACHET_TOKEN")
+	}
+	Config.SystemName = system.GetHostname()
 	flags := log.Llongfile | log.Ldate | log.Ltime
 	if len(os.Getenv("DEVELOPMENT")) > 0 {
 		flags = 0

--- a/main.go
+++ b/main.go
@@ -6,12 +6,12 @@ import (
 )
 
 func main() {
-	config := cachet.Config
+	cachet.LoadCachetConfigClassic()
 	log := cachet.Logger
 
-	log.Printf("System: %s, API: %s\n", config.SystemName, config.APIUrl)
-	log.Printf("Starting %d monitors:\n", len(config.Monitors))
-	for _, mon := range config.Monitors {
+	log.Printf("System: %s, API: %s\n", cachet.Config.SystemName, cachet.Config.APIUrl)
+	log.Printf("Starting %d monitors:\n", len(cachet.Config.Monitors))
+	for _, mon := range cachet.Config.Monitors {
 		log.Printf(" %s: GET %s & Expect HTTP %d\n", mon.Name, mon.URL, mon.ExpectedStatusCode)
 		if mon.MetricID > 0 {
 			log.Printf(" - Logs lag to metric id: %d\n", mon.MetricID)
@@ -22,7 +22,7 @@ func main() {
 
 	ticker := time.NewTicker(time.Second)
 	for range ticker.C {
-		for _, mon := range config.Monitors {
+		for _, mon := range cachet.Config.Monitors {
 			go mon.Run()
 		}
 	}


### PR DESCRIPTION
It was hard to plug this on another package, the main point is that config is loaded with usage of `init` and have `os.Exit(1)` inside this function.
`init` was removed in favor of `LoadCachetConfigClassic` which have to be called to load the config.
A `LoadEmptyConfig` function has been created to initialize a `CachetConfig` without loading data from files (web or local).
Now a project can use this project with the possibility to set the config by itself.
