### PR TITLE
Timeout exceeded while awaiting headers

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	wg := &sync.WaitGroup{}
 	for _, mon := range cfg.Monitors {
-		cfg.Logger.Printf(" Starting %s: %d seconds check interval\n - %v %s", mon.Name, mon.CheckInterval, mon.Method, mon.URL)
+		cfg.Logger.Printf(" Starting %s: %d seconds check interval\n - %v %s (%d second/s timeout)", mon.Name, mon.CheckInterval, mon.Method, mon.URL, mon.HttpTimeout)
 
 		// print features
 		if mon.ExpectedStatusCode > 0 {

--- a/example.config.json
+++ b/example.config.json
@@ -9,6 +9,7 @@
       "threshold": 80,
       "component_id": 1,
       "interval": 10,
+      "timeout": 5,
       "expected_status_code": 200,
       "strict_tls": true
     }

--- a/monitor.go
+++ b/monitor.go
@@ -13,8 +13,8 @@ import (
 	"time"
 )
 
-const HttpTimeout = time.Duration(time.Second)
 const DefaultInterval = 60
+const DefaultTimeout = 1
 const DefaultTimeFormat = "15:04:05 Jan 2 MST"
 
 // Monitor data model
@@ -24,6 +24,7 @@ type Monitor struct {
 	Method        string        `json:"method"`
 	StrictTLS     bool          `json:"strict_tls"`
 	CheckInterval time.Duration `json:"interval"`
+	HttpTimeout   time.Duration `json:"timeout"`
 
 	MetricID    int `json:"metric_id"`
 	ComponentID int `json:"component_id"`
@@ -100,7 +101,7 @@ func (monitor *Monitor) Tick() {
 
 func (monitor *Monitor) doRequest() bool {
 	client := &http.Client{
-		Timeout: HttpTimeout,
+		Timeout: time.Duration(monitor.HttpTimeout * time.Second),
 	}
 	if monitor.StrictTLS == false {
 		client.Transport = &http.Transport{
@@ -211,6 +212,10 @@ func (monitor *Monitor) ValidateConfiguration() error {
 
 	if monitor.CheckInterval < 1 {
 		monitor.CheckInterval = DefaultInterval
+	}
+
+	if monitor.HttpTimeout < 1 {
+		monitor.HttpTimeout = DefaultTimeout
 	}
 
 	monitor.Method = strings.ToUpper(monitor.Method)

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,8 @@ Configuration
     "strict_tls": true,
     // seconds between checks
     "interval": 10,
+    // seconds for http timeout
+    "timeout": 5,
     // post lag to cachet metric (graph)
     // note either metric ID or component ID are required
     "metric_id": <metric id>,


### PR DESCRIPTION
I'm using cachet-monitor v2.0

Got this message in the incident.

`Get http://someurl/health: net/http: request canceled (Client.Timeout exceeded while awaiting headers)`

The health check URL is fine, but somehow its response is slightly slow (the slowest take up to 3000ms). But I think it is still acceptable. Is there a way to control the timeout value?

Thanks
