### PR TITLE
component status being returned as a json string

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -83,7 +83,7 @@ func (incident *Incident) GetComponentStatus(cfg *CachetMonitor) (int, error) {
 
 	var data struct {
 		Component struct {
-			Status int `json:"status"`
+			Status int `json:"status,string"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &data); err != nil {


### PR DESCRIPTION
Fixes issue when Cachet returns the component status as a string in JSON instead of a INT.
