### PR TITLE
fix component status parsing

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -82,7 +82,7 @@ func (incident *Incident) GetComponentStatus(cfg *CachetMonitor) (int, error) {
 	}
 
 	var data struct {
-		Status int `json:"status"`
+		Status int `json:"status,string"`
 	}
 	if err := json.Unmarshal(body.Data, &data); err != nil {
 		return 0, fmt.Errorf("Cannot parse component body: %v. Err = %v", string(body.Data), err)


### PR DESCRIPTION
The Cachet API returns component status as a string, but cachet-monitor attempts to parse it as int, resulting in "cannot unmarshal string into Go value of type int".
This applies at least as early as cachet 2.3.12 - 29/06/2017.