### PR TITLE
add option to fetch open incidents on startup

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
-	cachet "github.com/castawaylabs/cachet-monitor"
+	cachet "github.com/aberfeldy/cachet-monitor"
 	docopt "github.com/docopt/docopt-go"
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v2"
@@ -38,7 +38,8 @@ Options:
   -h --help                      Show this screen.
   --version                      Show version
   --immediate                    Tick immediately (by default waits for first defined interval)
-  
+  --restarted                    Get open incidents before start monitoring (if monitor died or restarted)
+
 Environment varaibles:
   CACHET_API      override API url from configuration
   CACHET_TOKEN    override API token from configuration
@@ -54,6 +55,10 @@ func main() {
 
 	if immediate, ok := arguments["--immediate"]; ok {
 		cfg.Immediate = immediate.(bool)
+	}
+
+	if restarted, ok := arguments["--restarted"]; ok{
+		cfg.Restarted = restarted.(bool)
 	}
 
 	if name := arguments["--name"]; name != nil {

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type CachetMonitor struct {
 
 	Monitors  []MonitorInterface `json:"-" yaml:"-"`
 	Immediate bool               `json:"-" yaml:"-"`
+	Restarted bool               `json:"-" yaml:"-"`
 }
 
 // Validate configuration

--- a/incident.go
+++ b/incident.go
@@ -21,6 +21,34 @@ type Incident struct {
 	ComponentStatus int `json:"component_status"`
 }
 
+//Get the last still open incident
+func (mon *AbstractMonitor) Get(cfg *CachetMonitor) (*Incident, error) {
+
+	requestType := "GET"
+	requestURL := fmt.Sprintf("/incidents?component_id=%d", mon.ComponentID)
+	_, body, err := cfg.API.NewRequest(requestType, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]Incident,0)
+	if err := json.Unmarshal(body.Data, &data); err != nil {
+		return nil, fmt.Errorf("Cannot parse incident body: %v, %v", err, string(body.Data))
+	}
+	//filter out resolved incidents
+	openIncidents := make([]Incident, 0)
+	for _, i := range data {
+		if i.Status < 4 {
+			openIncidents = append(openIncidents, i)
+		}
+	}
+	if len(openIncidents) == 0 {
+		return nil, nil
+	}
+	return &openIncidents[0], nil
+
+}
+
+
 // Send - Create or Update incident
 func (incident *Incident) Send(cfg *CachetMonitor) error {
 	switch incident.Status {

--- a/incident.go
+++ b/incident.go
@@ -30,7 +30,7 @@ func (mon *AbstractMonitor) Get(cfg *CachetMonitor) (*Incident, error) {
 	if err != nil {
 		return nil, err
 	}
-	data := make([]Incident,0)
+	data := make([]Incident, 0)
 	if err := json.Unmarshal(body.Data, &data); err != nil {
 		return nil, fmt.Errorf("Cannot parse incident body: %v, %v", err, string(body.Data))
 	}
@@ -47,7 +47,6 @@ func (mon *AbstractMonitor) Get(cfg *CachetMonitor) (*Incident, error) {
 	return &openIncidents[0], nil
 
 }
-
 
 // Send - Create or Update incident
 func (incident *Incident) Send(cfg *CachetMonitor) error {

--- a/monitor.go
+++ b/monitor.go
@@ -120,7 +120,7 @@ func (mon *AbstractMonitor) ClockStart(cfg *CachetMonitor, iface MonitorInterfac
 
 	if cfg.Restarted {
 		initialIncident, err := mon.Get(cfg)
-		if err != nil{
+		if err != nil {
 			logrus.Warn("could not fetch initial incident: %v", err)
 		}
 		if initialIncident != nil {

--- a/monitor.go
+++ b/monitor.go
@@ -118,6 +118,16 @@ func (mon *AbstractMonitor) ClockStart(cfg *CachetMonitor, iface MonitorInterfac
 		mon.tick(iface)
 	}
 
+	if cfg.Restarted {
+		initialIncident, err := mon.Get(cfg)
+		if err != nil{
+			logrus.Warn("could not fetch initial incident: %v", err)
+		}
+		if initialIncident != nil {
+			mon.incident = initialIncident
+		}
+	}
+
 	ticker := time.NewTicker(mon.Interval * time.Second)
 	for {
 		select {

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,7 @@ Options:
   -h --help                      Show this screen.
   --version                      Show version
   --immediate                    Tick immediately (by default waits for first defined interval)
+  --restarted                    Get open incidents before start monitoring (if monitor died or restarted)
   
 Environment varaibles:
   CACHET_API      override API url from configuration


### PR DESCRIPTION
I'm using this nice tool (thx for the work on it) in a docker environment on a cluster, so things can happen and it needs to be restarted somewhere else. But if an incident was opened before it got killed, cachet-monitor is not able to resolve it, if the monitor is up and saturated again. 
This little function allows it to prefetch an open incident after restart and before start pinging again.
Maybe it's something you want to include as well.
