### PR TITLE
add version information

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -44,8 +44,10 @@ Environment varaibles:
   CACHET_TOKEN    override API token from configuration
   CACHET_DEV      set to enable dev logging`
 
+var version string
+
 func main() {
-	arguments, _ := docopt.Parse(usage, nil, true, "cachet-monitor", false)
+	arguments, _ := docopt.Parse(usage, nil, true, version, false)
 
 	cfg, err := getConfiguration(arguments["--config"].(string))
 	if err != nil {


### PR DESCRIPTION
Sets at build time the version information with:

    -ldflags "-X main.version=3.0.0" 

the --version will display software version

Closes #77