### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# build stage
+FROM golang:alpine AS build-env
+ENV WORKDIR /go/src/github.com/castawaylabs/cachet-monitor
+RUN mkdir -p ${WORKDIR}
+ADD . ${WORKDIR}
+WORKDIR ${WORKDIR}
+RUN apk add --no-cache ca-certificates git
+RUN go get -v github.com/Sirupsen/logrus \
+      github.com/docopt/docopt-go \
+      github.com/mitchellh/mapstructure \
+      gopkg.in/yaml.v2 \
+      github.com/miekg/dns
+RUN cd cli && go build -o /app/cachet-monitor
+
+# final stage
+FROM alpine
+RUN apk add --no-cache ca-certificates
+COPY --from=build-env /app/cachet-monitor /app/
+WORKDIR /app
+RUN chmod a+x cachet-monitor
+ENTRYPOINT ["/app/cachet-monitor"]


### PR DESCRIPTION
### build the image
```
$ docker build -t cachet-monitor:test .  
Sending build context to Docker daemon  497.2kB
Step 1/11 : FROM golang:alpine AS build-env
 ---> d4953956cf1e
Step 2/11 : ADD . /src
 ---> 8156fb469e6c
Step 3/11 : WORKDIR /src/cli
 ---> Running in f90226bc1efc
Removing intermediate container f90226bc1efc
 ---> aee1e8cba8d4
Step 4/11 : RUN apk add git
 ---> Running in 44de78970dbf
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
(1/6) Installing nghttp2-libs (1.35.1-r0)
(2/6) Installing libssh2 (1.8.0-r4)
(3/6) Installing libcurl (7.64.0-r1)
(4/6) Installing expat (2.2.6-r0)
(5/6) Installing pcre2 (10.32-r1)
(6/6) Installing git (2.20.1-r0)
Executing busybox-1.29.3-r10.trigger
OK: 20 MiB in 21 packages
Removing intermediate container 44de78970dbf
 ---> 94287b04a332
Step 5/11 : RUN go get -v -d ./...
 ---> Running in adfe2bb590d7
github.com/Sirupsen/logrus (download)
Fetching https://golang.org/x/crypto/ssh/terminal?go-get=1
Parsing meta tags from https://golang.org/x/crypto/ssh/terminal?go-get=1 (status code 200)
get "golang.org/x/crypto/ssh/terminal": found meta tag get.metaImport{Prefix:"golang.org/x/crypto", VCS:"git", RepoRoot:"https://go.googlesource.com/crypto"} at https://golang.org/x/crypto/ssh/terminal?go-get=1
get "golang.org/x/crypto/ssh/terminal": verifying non-authoritative meta tag
Fetching https://golang.org/x/crypto?go-get=1
Parsing meta tags from https://golang.org/x/crypto?go-get=1 (status code 200)
golang.org/x/crypto (download)
Fetching https://golang.org/x/sys/unix?go-get=1
Parsing meta tags from https://golang.org/x/sys/unix?go-get=1 (status code 200)
get "golang.org/x/sys/unix": found meta tag get.metaImport{Prefix:"golang.org/x/sys", VCS:"git", RepoRoot:"https://go.googlesource.com/sys"} at https://golang.org/x/sys/unix?go-get=1
get "golang.org/x/sys/unix": verifying non-authoritative meta tag
Fetching https://golang.org/x/sys?go-get=1
Parsing meta tags from https://golang.org/x/sys?go-get=1 (status code 200)
golang.org/x/sys (download)
github.com/castawaylabs/cachet-monitor (download)
github.com/miekg/dns (download)
github.com/docopt/docopt-go (download)
github.com/mitchellh/mapstructure (download)
Fetching https://gopkg.in/yaml.v2?go-get=1
Parsing meta tags from https://gopkg.in/yaml.v2?go-get=1 (status code 200)
get "gopkg.in/yaml.v2": found meta tag get.metaImport{Prefix:"gopkg.in/yaml.v2", VCS:"git", RepoRoot:"https://gopkg.in/yaml.v2"} at https://gopkg.in/yaml.v2?go-get=1
gopkg.in/yaml.v2 (download)
Removing intermediate container adfe2bb590d7
 ---> 28646c593ab3
Step 6/11 : RUN go build -o cachet-monitor
 ---> Running in 5a442467bd3b
Removing intermediate container 5a442467bd3b
 ---> 7088622eafff
Step 7/11 : RUN chmod a+x cachet-monitor
 ---> Running in 705c455e0346
Removing intermediate container 705c455e0346
 ---> dd9eba923d55
Step 8/11 : FROM alpine
 ---> caf27325b298
Step 9/11 : COPY --from=build-env /src /src
 ---> 17da5e2afd15
Step 10/11 : WORKDIR /src
 ---> Running in a4a0f91b65e2
Removing intermediate container a4a0f91b65e2
 ---> bcd617e3449d
Step 11/11 : ENTRYPOINT ["/src/cli/cachet-monitor"]
 ---> Running in bc2f3a874fcb
Removing intermediate container bc2f3a874fcb
 ---> 1a5b7de48769
Successfully built 1a5b7de48769
Successfully tagged cachet-monitor:test
```

### test the image
```
$ docker run cachet-monitor -h 
cachet-monitor

Usage:
  cachet-monitor (-c PATH | --config PATH) [--log=LOGPATH] [--name=NAME] [--immediate]
  cachet-monitor -h | --help | --version

Arguments:
  PATH     path to config.json
  LOGPATH  path to log output (defaults to STDOUT)
  NAME     name of this logger

Examples:
  cachet-monitor -c /root/cachet-monitor.json
  cachet-monitor -c /root/cachet-monitor.json --log=/var/log/cachet-monitor.log --name="development machine"

Options:
  -c PATH.json --config PATH     Path to configuration file
  -h --help                      Show this screen.
  --version                      Show version
  --immediate                    Tick immediately (by default waits for first defined interval)

Environment varaibles:
  CACHET_API      override API url from configuration
  CACHET_TOKEN    override API token from configuration
  CACHET_DEV      set to enable dev logging
```

### run the cachet-monitor
```
$ docker run -t cachet-monitor -c example.config.json
INFO[0000] System: 161401f5bcc6
INFO[0000] API: https://demo.cachethq.io/api/v1
INFO[0000] Monitors: 2
INFO[0000] Pinging cachet
INFO[0001] Ping OK
INFO[0001] Starting Monitor #0:
INFO[0001] Features:
 - Type: http
 - Name: google
 - Method: POST
INFO[0001] Starting Monitor #1:
INFO[0001] Features:
 - Type: dns
 - Name: dns
INFO[0002] monitor down 100.00%/80.00%                   fields.time="06/03/2019 09:07:40 UTC" monitor=google
INFO[0002] monitor is up                                 fields.time="06/03/2019 09:07:40 UTC" monitor=dns
WARN[0002] Could not log metric! ID: 4, err: <nil>
INFO[0003] monitor is up                                 fields.time="06/03/2019 09:07:41 UTC" monitor=dns
INFO[0003] monitor down 100.00%/80.00%                   fields.time="06/03/2019 09:07:41 UTC" monitor=google
WARN[0003] Could not log metric! ID: 4, err: <nil>
INFO[0004] monitor is up                                 fields.time="06/03/2019 09:07:42 UTC" monitor=dns
INFO[0004] monitor down 100.00%/80.00%                   fields.time="06/03/2019 09:07:42 UTC" monitor=google
WARN[0004] Could not log metric! ID: 4, err: <nil>
INFO[0005] monitor down 100.00%/80.00%                   fields.time="06/03/2019 09:07:43 UTC" monitor=google
INFO[0005] monitor is up                                 fields.time="06/03/2019 09:07:43 UTC" monitor=dns
```