### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.12-alpine as builder
+
+RUN apk add --no-cache make curl git gcc musl-dev linux-headers
+
+ADD . /go/src/github.com/CastawayLabs/cachet-monitor
+RUN cd /go/src/github.com/CastawayLabs/cachet-monitor/cli && go get && go build -o cachet-monitor
+
+# Copy into a second stage container
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /go/src/github.com/CastawayLabs/cachet-monitor/cli/cachet-monitor /usr/local/bin/
+
+ENTRYPOINT ["cachet-monitor"]


### PR DESCRIPTION
Tested & ran it, all looks good. Possible to get an automated docker hub build?

Output:
```
Sending build context to Docker daemon  499.7kB
Step 1/8 : FROM golang:1.12-alpine as builder
 ---> c0e5aac9423b
Step 2/8 : RUN apk add --no-cache make curl git gcc musl-dev linux-headers
 ---> Using cache
 ---> cd609a027104
Step 3/8 : ADD . /go/src/github.com/CastawayLabs/cachet-monitor
 ---> c41f8a0d09d1
Step 4/8 : RUN cd /go/src/github.com/CastawayLabs/cachet-monitor/cli && go get && go build -o cachet-monitor
 ---> Running in 899b681afff7
Removing intermediate container 899b681afff7
 ---> 87c22efb0ca8
Step 5/8 : FROM alpine:latest
 ---> 3f53bb00af94
Step 6/8 : RUN apk add --no-cache ca-certificates
 ---> Using cache
 ---> ccef5ffb38d6
Step 7/8 : COPY --from=builder /go/src/github.com/CastawayLabs/cachet-monitor/cli/cachet-monitor /usr/local/bin/
 ---> 00d124e66f00
Step 8/8 : ENTRYPOINT ["cachet-monitor"]
 ---> Running in 56b5889cf8e8
Removing intermediate container 56b5889cf8e8
 ---> 71174342fab6
Successfully built 71174342fab6
Successfully tagged cachet-monitor:latest
```