### PR TITLE
Accepting basic auth headers

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
-	cachet "github.com/castawaylabs/cachet-monitor"
 	docopt "github.com/docopt/docopt-go"
 	"github.com/mitchellh/mapstructure"
+	cachet "github.com/viitech/cachet-monitor"
 	"gopkg.in/yaml.v2"
 )
 

--- a/http.go
+++ b/http.go
@@ -34,6 +34,7 @@ type HTTPMonitor struct {
 	Method             string
 	ExpectedStatusCode int `mapstructure:"expected_status_code"`
 	Headers            map[string]string
+	Auth               map[string]string
 
 	// compiled to Regexp
 	ExpectedBody string `mapstructure:"expected_body"`
@@ -45,6 +46,10 @@ func (monitor *HTTPMonitor) test() bool {
 	req, err := http.NewRequest(monitor.Method, monitor.Target, nil)
 	for k, v := range monitor.Headers {
 		req.Header.Add(k, v)
+	}
+
+	if monitor.Auth != nil {
+		req.SetBasicAuth(monitor.Auth["username"], monitor.Auth["password"])
 	}
 
 	transport := http.DefaultTransport.(*http.Transport)


### PR DESCRIPTION
Currently its not accepting basic auth, it shows an error "bad request 400 status" if you add auth in headers.
This fixes using the following inside your site monitor object in config.json file  
```json
"auth": {
  "username": "USERNAME_HERE",
  "password": "PASSWORD_HERE"
}
```

This fixes #87 
